### PR TITLE
Added support for durability via `:` separator.

### DIFF
--- a/src/main/java/org/shanerx/tradeshop/itrade/CreateISign.java
+++ b/src/main/java/org/shanerx/tradeshop/itrade/CreateISign.java
@@ -67,6 +67,18 @@ boolean signIsValid = true; // If this is true, the information on the sign is v
         String[] info2 = line2.split(" ");
         
         if ( info1.length != 2 || info2.length != 2 ) {
+        	signIsValid = false;
+        }
+        
+		
+		if (line1.split(":").length > 1) {
+			info1[1] = info1[1].split(":")[0];
+		}
+		if (line2.split(":").length > 1) {
+			info2[1] = info2[1].split(":")[0];
+		}
+        
+        if ( info1.length != 2 || info2.length != 2 ) {
             signIsValid = false;
         }
         

--- a/src/main/java/org/shanerx/tradeshop/itrade/ITrade.java
+++ b/src/main/java/org/shanerx/tradeshop/itrade/ITrade.java
@@ -64,7 +64,18 @@ public class ITrade extends Utils implements Listener {
             String[] info2 = line2.split(" ");
             
             int amount1 = Integer.parseInt(info1[0]);
-            int amount2 = Integer.parseInt(info2[0]);
+			int amount2 = Integer.parseInt(info2[0]);
+			
+			int durability1 = 0;
+			int durability2 = 0;
+			if (line1.split(":").length > 1) {
+				durability1 = Integer.parseInt(info1[1].split(":")[1]);
+				info1[1] = info1[1].split(":")[0];
+			}
+			if (line2.split(":").length > 1) {
+				durability2 = Integer.parseInt(info2[1].split(":")[1]);
+				info2[1] = info2[1].split(":")[0];
+			}
             
             String item_name1, item_name2;
             
@@ -93,10 +104,10 @@ public class ITrade extends Utils implements Listener {
                     {
                         if(i.getType() == item2.getType())
                         {
-                            if(i.getAmount() >= amount2)
+                            if(i.getAmount() >= amount2  && i.getDurability() == durability2)
                             {
                                 item2.setData(i.getData());
-                                item2.setDurability(i.getDurability());
+                                item2.setDurability((short)durability2);
                                 item2.setItemMeta(i.getItemMeta());
                                 item2check = true;
                                 break;
@@ -111,12 +122,12 @@ public class ITrade extends Utils implements Listener {
                 {
                     if(i != null)
                     {
-                        if(i.getType() == item1.getType())
+                        if(i.getType() == item1.getType()  && i.getDurability() == durability1)
                         {
                             if(i.getAmount() >= amount1)
                             {
                                 item1.setData(i.getData());
-                                item1.setDurability(i.getDurability());
+                                item1.setDurability((short)durability1);
                                 item1.setItemMeta(i.getItemMeta());
                                 item1check = true;
                                 break;

--- a/src/main/java/org/shanerx/tradeshop/trade/CreateSign.java
+++ b/src/main/java/org/shanerx/tradeshop/trade/CreateSign.java
@@ -75,6 +75,14 @@ public class CreateSign extends Utils implements Listener {
         	signIsValid = false;
         }
         
+		
+		if (line1.split(":").length > 1) {
+			info1[1] = info1[1].split(":")[0];
+		}
+		if (line2.split(":").length > 1) {
+			info2[1] = info2[1].split(":")[0];
+		}
+        
         int amount1 = 0;
         int amount2 = 0;
         String item_name1 = null;

--- a/src/main/java/org/shanerx/tradeshop/trade/CreateSign.java
+++ b/src/main/java/org/shanerx/tradeshop/trade/CreateSign.java
@@ -76,10 +76,14 @@ public class CreateSign extends Utils implements Listener {
         }
         
 		
+        int durability1 = 0;
+		int durability2 = 0;
 		if (line1.split(":").length > 1) {
+			durability1 = Integer.parseInt(info1[1].split(":")[1]);
 			info1[1] = info1[1].split(":")[0];
 		}
 		if (line2.split(":").length > 1) {
+			durability2 = Integer.parseInt(info2[1].split(":")[1]);
 			info2[1] = info2[1].split(":")[0];
 		}
         
@@ -130,10 +134,11 @@ public class CreateSign extends Utils implements Listener {
 		BlockState chestState = Bukkit.getServer().getWorld(world).getBlockAt(new Location(event.getBlock().getWorld(), x, y - 1, z)).getState();
 		Chest chest = (Chest) chestState;
 		Inventory chestInventory = chest.getInventory();
-		
+		item1 = new ItemStack(Material.getMaterial(item_name1), amount1);
+		item1.setDurability((short)durability1);
 		event.setLine(0, ChatColor.DARK_GREEN + "[Trade]");
-		
-		if (chestInventory.contains(Enum.valueOf(Material.class, item_name1))) {
+		if (chestInventory.containsAtLeast(item1, amount1)) {
+			
 			event.setLine(0, ChatColor.DARK_GREEN + "[Trade]");
 	    	event.getPlayer().sendMessage(ChatColor.translateAlternateColorCodes('&', getPrefix() + plugin.config.getString("successful-setup")));
 	    	return;

--- a/src/main/java/org/shanerx/tradeshop/trade/Trade.java
+++ b/src/main/java/org/shanerx/tradeshop/trade/Trade.java
@@ -55,8 +55,20 @@ public class Trade extends Utils implements Listener {
 			String[] info1 = line1.split(" ");
 			String[] info2 = line2.split(" ");
 			
+			
 			int amount1 = Integer.parseInt(info1[0]);
 			int amount2 = Integer.parseInt(info2[0]);
+			
+			int durability1 = 0;
+			int durability2 = 0;
+			if (line1.split(":").length > 1) {
+				durability1 = Integer.parseInt(info1[1].split(":")[1]);
+				info1[1] = info1[1].split(":")[0];
+			}
+			if (line2.split(":").length > 1) {
+				durability2 = Integer.parseInt(info2[1].split(":")[1]);
+				info2[1] = info2[1].split(":")[0];
+			}
 			
 			String item_name1, item_name2;
 			
@@ -83,10 +95,10 @@ public class Trade extends Utils implements Listener {
 			} else {
 				for (ItemStack i : playerInventory.getContents()) {
 					if (i != null) {
-						if (i.getType() == item2.getType()) {
+						if (i.getType() == item2.getType() && i.getDurability() == durability2) {
 							if (i.getAmount() >= amount2) {
 								item2.setData(i.getData());
-								item2.setDurability(i.getDurability());
+								item2.setDurability((short)durability2);
 								item2.setItemMeta(i.getItemMeta());
 								item2check = true;
 								break;
@@ -103,10 +115,10 @@ public class Trade extends Utils implements Listener {
 			} else {
 				for (ItemStack i : chestInventory.getContents()) {
 					if (i != null) {
-						if (i.getType() == item1.getType()) {
+						if (i.getType() == item1.getType() && i.getDurability() == durability1) {
 							if (i.getAmount() >= amount1) {
 								item1.setData(i.getData());
-								item1.setDurability(i.getDurability());
+								item1.setDurability((short)durability1);
 								item1.setItemMeta(i.getItemMeta());
 								item1check = true;
 								break;


### PR DESCRIPTION
This solves Issue #1.

Changes in brief:
* Added (int) durability1, durability2.
* `:` separator on sign.
* Checks to make sure durability for the stack matches the sign.
* Default durability is 0

Extra:
* Ensures that armor/weapons have full durability unless specified.