### PR TITLE
Multi-access (#19) fixes

### DIFF
--- a/src/main/java/org/shanerx/tradeshop/TradeShop.java
+++ b/src/main/java/org/shanerx/tradeshop/TradeShop.java
@@ -212,6 +212,7 @@ public class TradeShop extends JavaPlugin {
         addMessage("unsuccessful-shop-members", "&aThat player is either already on the shop, or you have reached the maximum number of users!");
         addMessage("who-message", "&6Shop users are:\n&2Owners: &e{OWNERS}\n&2Members: &e{MEMBERS}");
         addMessage("self-owned", "&cYou cannot buy from a shop in which you are a user.");
+        addMessage("not-owner", "&cYou cannot create a sign for a shop that you do not own.");
 
         save();
     }

--- a/src/main/java/org/shanerx/tradeshop/Utils.java
+++ b/src/main/java/org/shanerx/tradeshop/Utils.java
@@ -32,10 +32,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.permissions.Permission;
 import org.bukkit.plugin.PluginDescriptionFile;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+
 
 /**
  * This class contains a bunch of utility methods that
@@ -365,12 +363,32 @@ public class Utils {
     public Sign findShopSign(Block chest) {
         ArrayList<BlockFace> faces = plugin.getAllowedDirections();
         Collections.reverse(faces);
+        ArrayList<BlockFace> flatFaces = new ArrayList<BlockFace>(Arrays.asList(BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST));
+        boolean isDouble = false;
+        BlockFace doubleSide = null;
 
         for (BlockFace face : faces) {
             Block relative = chest.getRelative(face);
-            if (isShopSign(relative))
+            if (isShopSign(relative)) {
                 return (Sign) chest.getRelative(face).getState();
+            } else if (flatFaces.contains(face) && (chest.getType().equals(Material.CHEST) || chest.getType().equals(Material.TRAPPED_CHEST))) {
+                if (relative.getType().equals(chest.getType())) {
+                    isDouble = true;
+                    doubleSide = face;
+                }
+            }
         }
+
+        if (isDouble) {
+            chest = chest.getRelative(doubleSide);
+            for (BlockFace face : faces) {
+                Block relative = chest.getRelative(face);
+                if (isShopSign(relative)) {
+                    return (Sign) chest.getRelative(face).getState();
+                }
+            }
+        }
+
         return null;
     }
 

--- a/src/main/java/org/shanerx/tradeshop/bitrade/BiShopCreateEventListener.java
+++ b/src/main/java/org/shanerx/tradeshop/bitrade/BiShopCreateEventListener.java
@@ -21,6 +21,7 @@
 
 package org.shanerx.tradeshop.bitrade;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -86,6 +87,17 @@ public class BiShopCreateEventListener extends Utils implements Listener {
             event.setLine(3, "");
             player.sendMessage(colorize(getPrefix() + plugin.getMessages().getString("no-chest")));
             return;
+        }
+
+        if (findShopChest(s.getBlock()) != null && getShopUsers(findShopChest(s.getBlock())).size() > 0) {
+            if (!getShopOwners(s).contains(Bukkit.getOfflinePlayer(player.getUniqueId()))) {
+                event.setLine(0, "");
+                event.setLine(1, "");
+                event.setLine(2, "");
+                event.setLine(3, "");
+                player.sendMessage(colorize(getPrefix() + plugin.getMessages().getString("not-owner")));
+                return;
+            }
         }
 
         boolean signIsValid = true;

--- a/src/main/java/org/shanerx/tradeshop/commands/Executor.java
+++ b/src/main/java/org/shanerx/tradeshop/commands/Executor.java
@@ -36,7 +36,6 @@ import org.shanerx.tradeshop.Utils;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Set;
 
 public class Executor extends Utils implements CommandExecutor {
 
@@ -149,10 +148,10 @@ public class Executor extends Utils implements CommandExecutor {
                 Sign s;
 
                 try {
-                    if (p.getTargetBlock((Set<Material>) null, plugin.getSettings().getInt("max-edit-distance")) == null)
-                        throw new NoSuchFieldException();
-
                     b = p.getTargetBlock((HashSet<Byte>) null, plugin.getSettings().getInt("max-edit-distance"));
+
+                    if (b == null || b.getType() == Material.AIR)
+                        throw new NoSuchFieldException();
 
                     if (isSign(b)) {
 
@@ -240,6 +239,7 @@ public class Executor extends Utils implements CommandExecutor {
 
             }
             OfflinePlayer target = Bukkit.getOfflinePlayer(args[1]);
+            b = findShopChest(findShopSign(b).getBlock());
 
             switch (args[0].toLowerCase()) {
                 case "addowner":

--- a/src/main/java/org/shanerx/tradeshop/trade/ShopCreateEventListener.java
+++ b/src/main/java/org/shanerx/tradeshop/trade/ShopCreateEventListener.java
@@ -21,6 +21,7 @@
 
 package org.shanerx.tradeshop.trade;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -67,6 +68,7 @@ public class ShopCreateEventListener extends Utils implements Listener {
             player.sendMessage(colorize(getPrefix() + plugin.getMessages().getString("no-ts-create-permission")));
             return;
         }
+
         if (!plugin.getAllowedInventories().contains(chest.getType())) {
             event.setLine(0, ChatColor.DARK_RED + "[Trade]");
             event.setLine(1, "");
@@ -75,6 +77,18 @@ public class ShopCreateEventListener extends Utils implements Listener {
             player.sendMessage(colorize(getPrefix() + plugin.getMessages().getString("no-chest")));
             return;
         }
+
+        if (findShopChest(s.getBlock()) != null && getShopUsers(findShopChest(s.getBlock())).size() > 0) {
+            if (!getShopOwners(s).contains(Bukkit.getOfflinePlayer(player.getUniqueId()))) {
+                event.setLine(0, "");
+                event.setLine(1, "");
+                event.setLine(2, "");
+                event.setLine(3, "");
+                player.sendMessage(colorize(getPrefix() + plugin.getMessages().getString("not-owner")));
+                return;
+            }
+        }
+
         boolean signIsValid = true; // If this is true, the information on the sign is valid!
 
         String line1 = event.getLine(1);


### PR DESCRIPTION
- Double chests(Trap and normal) check for the first sign on both blocks, starting with the block clicked and then going to the next it can find in the 4 cardinal directions
- Non-Owners can no longer create signs for shops they do not own
- Had to manually import things as the IDE keeps switching to a wildcard after a certain number of imports

(Fixes for #19 )