### PR TITLE
Fixed name not being reset when chest is broken

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.shanerx</groupId>
     <artifactId>tradeshop</artifactId>
-    <version>1.7.1-BETA</version>
+    <version>1.7.2-BETA</version>
     <name>TradeShop</name>
     <url>http://maven.apache.org</url>
 

--- a/src/main/java/org/shanerx/tradeshop/Utils.java
+++ b/src/main/java/org/shanerx/tradeshop/Utils.java
@@ -724,6 +724,67 @@ public class Utils {
     }
 
     /**
+     * Sets the name of the inventory
+     *
+     * @param state   blockState to change the name of
+     * @param name    original name of inventory, null to use generic name
+     * @param owners  List of inventory owners
+     * @param members List of inventory members
+     * @return void
+     */
+    public void changeInvName(BlockState state, String name, List<OfflinePlayer> owners, List<OfflinePlayer> members) {
+        StringBuilder sb = new StringBuilder();
+        if (name.equalsIgnoreCase("") || name == null) {
+            name = state.getType().name().toString();
+        }
+        sb.append(name + " <");
+        owners.forEach(o -> sb.append("o:" + o.getName() + ";"));
+        members.forEach(m -> sb.append("m:" + m.getName() + ";"));
+        sb.append(">");
+        setName((InventoryHolder) state, sb.toString());
+    }
+
+    /**
+     * Reads the name of the inventory
+     *
+     * @param state blockState to change the name of
+     * @return Name of inventory
+     */
+    public String readInvName(BlockState state) {
+        if (!plugin.getAllowedInventories().contains(state.getType())) {
+            return null;
+        }
+
+        Inventory inv = ((InventoryHolder) state).getInventory();
+        String[] names = inv.getName().split(" <");
+
+        if (names[0].equalsIgnoreCase("") || names[0] == null) {
+            return state.getType().name().toString();
+        } else {
+            return names[0];
+        }
+
+    }
+
+    /**
+     * Resets the name of the inventory
+     *
+     * @param state blockState to change the name of
+     * @return void
+     */
+    public void resetInvName(BlockState state) {
+        Inventory inv = ((InventoryHolder) state).getInventory();
+        String[] names = inv.getName().split(" <");
+
+        if (names[0].equalsIgnoreCase("") || names[0] == null) {
+            setName(((InventoryHolder) state), state.getType().name().toString());
+        } else {
+            setName(((InventoryHolder) state), names[0]);
+        }
+
+    }
+
+    /**
      * Adds a player to the members list of a TradeShop.
      * <br>
      * The target player is not required to be online at the time of the operation.
@@ -748,10 +809,7 @@ public class Utils {
             return false;
         }
 
-        StringBuilder sb = new StringBuilder();
-        owners.forEach(o -> sb.append("o:" + o.getName() + ";"));
-        members.forEach(m -> sb.append("m:" + m.getName() + ";"));
-        setName((InventoryHolder) b.getState(), sb.toString());
+        changeInvName(b.getState(), readInvName(b.getState()), owners, members);
         return true;
     }
 
@@ -781,10 +839,7 @@ public class Utils {
         List<OfflinePlayer> members = getShopMembers(b);
         members.remove(p);
 
-        StringBuilder sb = new StringBuilder();
-        owners.forEach(o -> sb.append("o:" + o.getName() + ";"));
-        members.forEach(m -> sb.append("m:" + m.getName() + ";"));
-        setName((InventoryHolder) b.getState(), sb.toString());
+        changeInvName(b.getState(), readInvName(b.getState()), owners, members);
     }
 
     /**
@@ -824,10 +879,7 @@ public class Utils {
             return false;
         }
 
-        StringBuilder sb = new StringBuilder();
-        owners.forEach(o -> sb.append("o:" + o.getName() + ";"));
-        members.forEach(m -> sb.append("m:" + m.getName() + ";"));
-        setName((InventoryHolder) b.getState(), sb.toString());
+        changeInvName(b.getState(), readInvName(b.getState()), owners, members);
         return true;
     }
 
@@ -857,10 +909,7 @@ public class Utils {
         List<OfflinePlayer> members = getShopMembers(b);
         owners.remove(p);
 
-        StringBuilder sb = new StringBuilder();
-        owners.forEach(o -> sb.append("o:" + o.getName() + ";"));
-        members.forEach(m -> sb.append("m:" + m.getName() + ";"));
-        setName((InventoryHolder) b.getState(), sb.toString());
+        changeInvName(b.getState(), readInvName(b.getState()), owners, members);
     }
 
     /**

--- a/src/main/java/org/shanerx/tradeshop/Utils.java
+++ b/src/main/java/org/shanerx/tradeshop/Utils.java
@@ -612,7 +612,7 @@ public class Utils {
                 }
             } else if (!owners.contains(Bukkit.getOfflinePlayer(s.getLine(3)))) {
                 owners.add(Bukkit.getOfflinePlayer(s.getLine(3)));
-                setName((InventoryHolder) b.getState(), "o:" + s.getLine(3));
+                changeInvName(b.getState(), readInvName(b.getState()), Collections.singletonList(plugin.getServer().getOfflinePlayer(s.getLine(3))), Collections.emptyList());
             }
         } catch (NullPointerException npe) {
         }
@@ -651,7 +651,7 @@ public class Utils {
                 }
                 return members;
             } else if (getShopOwners(s).size() == 0 || !getShopOwners(s).contains(Bukkit.getOfflinePlayer(s.getLine(3)))) {
-                setName((InventoryHolder) b, "o:" + s.getLine(3));
+                changeInvName(b, readInvName(b), Collections.singletonList(plugin.getServer().getOfflinePlayer(s.getLine(3))), members);
             }
         } catch (NullPointerException npe) {
         }
@@ -735,13 +735,13 @@ public class Utils {
     public void changeInvName(BlockState state, String name, List<OfflinePlayer> owners, List<OfflinePlayer> members) {
         StringBuilder sb = new StringBuilder();
         if (name.equalsIgnoreCase("") || name == null) {
-            name = state.getType().name().toString();
+            name = "";
         }
         sb.append(name + " <");
         owners.forEach(o -> sb.append("o:" + o.getName() + ";"));
         members.forEach(m -> sb.append("m:" + m.getName() + ";"));
         sb.append(">");
-        setName((InventoryHolder) state, sb.toString());
+        setName((InventoryHolder) state, sb.toString().replace("_", " "));
     }
 
     /**
@@ -756,10 +756,15 @@ public class Utils {
         }
 
         Inventory inv = ((InventoryHolder) state).getInventory();
+
+        if (((Nameable) state).getCustomName() == null) {
+            return "";
+        }
+
         String[] names = inv.getName().split(" <");
 
         if (names[0].equalsIgnoreCase("") || names[0] == null) {
-            return state.getType().name().toString();
+            return "";
         } else {
             return names[0];
         }
@@ -774,13 +779,20 @@ public class Utils {
      */
     public void resetInvName(BlockState state) {
         Inventory inv = ((InventoryHolder) state).getInventory();
-        String[] names = inv.getName().split(" <");
+        String name = inv.getName();
+        String[] temp = name.split(";");
 
-        if (names[0].equalsIgnoreCase("") || names[0] == null) {
-            setName(((InventoryHolder) state), state.getType().name().toString());
-        } else {
-            setName(((InventoryHolder) state), names[0]);
+        if (name.startsWith("o:")) {
+            name = "";
         }
+
+        String[] names = name.split(" <");
+
+        while (names[0].endsWith(" ")) {
+            names[0] = names[0].substring(0, name.length() - 2);
+        }
+
+        setName(((InventoryHolder) state), names[0]);
 
     }
 

--- a/src/main/java/org/shanerx/tradeshop/admin/AdminEventListener.java
+++ b/src/main/java/org/shanerx/tradeshop/admin/AdminEventListener.java
@@ -66,6 +66,7 @@ public class AdminEventListener extends Utils implements Listener {
 
         } else if (plugin.getAllowedInventories().contains(block.getType())) {
             if (player.hasPermission(getAdminPerm())) {
+                resetInvName(block.getState());
                 return;
             }
 
@@ -75,13 +76,16 @@ public class AdminEventListener extends Utils implements Listener {
                 if (s == null)
                     throw new Exception();
             } catch (Exception e) {
+                resetInvName(block.getState());
                 return;
             }
 
             if (!isShopSign(s.getBlock())) {
+                resetInvName(block.getState());
                 return;
 
             } else if (getShopOwners(s).contains(Bukkit.getOfflinePlayer(event.getPlayer().getUniqueId()))) {
+                resetInvName(block.getState());
                 return;
 
             }

--- a/src/main/java/org/shanerx/tradeshop/bitrade/BiShopCreateEventListener.java
+++ b/src/main/java/org/shanerx/tradeshop/bitrade/BiShopCreateEventListener.java
@@ -38,6 +38,8 @@ import org.shanerx.tradeshop.ShopType;
 import org.shanerx.tradeshop.TradeShop;
 import org.shanerx.tradeshop.Utils;
 
+import java.util.Collections;
+
 public class BiShopCreateEventListener extends Utils implements Listener {
 
     private TradeShop plugin;
@@ -133,7 +135,8 @@ public class BiShopCreateEventListener extends Utils implements Listener {
         Inventory chestInventory = ((InventoryHolder) chest.getState()).getInventory();
         event.setLine(0, ChatColor.DARK_GREEN + header);
         event.setLine(3, player.getName());
-        setName((InventoryHolder) chest.getState(), "o:" + player.getName());
+        changeInvName(chest.getState(), ((InventoryHolder) chest.getState()).getInventory().getName().toString(),
+                Collections.singletonList(plugin.getServer().getOfflinePlayer(player.getUniqueId())), Collections.emptyList());
 
         if (chestInventory.containsAtLeast(item1, amount1)) {
             event.getPlayer().sendMessage(colorize(getPrefix() + Message.SUCCESSFUL_SETUP));

--- a/src/main/java/org/shanerx/tradeshop/itrade/IShopCreateEventListener.java
+++ b/src/main/java/org/shanerx/tradeshop/itrade/IShopCreateEventListener.java
@@ -35,6 +35,8 @@ import org.shanerx.tradeshop.ShopType;
 import org.shanerx.tradeshop.TradeShop;
 import org.shanerx.tradeshop.Utils;
 
+import java.util.Collections;
+
 public class IShopCreateEventListener extends Utils implements Listener {
 
     private TradeShop plugin;
@@ -65,7 +67,6 @@ public class IShopCreateEventListener extends Utils implements Listener {
             getShopOwners(s).stream().forEach(op -> {
                 if (!op.getName().equalsIgnoreCase(plugin.getSettings().getString("itrade-shop-name"))) {
                     failedSign(event, ShopType.ITRADE, Message.NOT_OWNER);
-                    return;
                 }
             });
         }
@@ -124,7 +125,8 @@ public class IShopCreateEventListener extends Utils implements Listener {
         }
 
         if (chest != null) {
-            setName((InventoryHolder) chest.getState(), "o:" + plugin.getSettings().getString("itrade-shop-name"));
+            changeInvName(chest.getState(), ((InventoryHolder) chest.getState()).getInventory().getName().toString(),
+                    Collections.singletonList(plugin.getServer().getOfflinePlayer(plugin.getSettings().getString("itrade-shop-name"))), Collections.emptyList());
         }
 
         event.setLine(0, ChatColor.DARK_GREEN + header);

--- a/src/main/java/org/shanerx/tradeshop/trade/ShopCreateEventListener.java
+++ b/src/main/java/org/shanerx/tradeshop/trade/ShopCreateEventListener.java
@@ -37,6 +37,8 @@ import org.shanerx.tradeshop.ShopType;
 import org.shanerx.tradeshop.TradeShop;
 import org.shanerx.tradeshop.Utils;
 
+import java.util.Collections;
+
 public class ShopCreateEventListener extends Utils implements Listener {
 
     private TradeShop plugin;
@@ -133,7 +135,8 @@ public class ShopCreateEventListener extends Utils implements Listener {
         Inventory chestInventory = ((InventoryHolder) chest.getState()).getInventory();
         event.setLine(0, ChatColor.DARK_GREEN + header);
         event.setLine(3, player.getName());
-        setName((InventoryHolder) chest.getState(), "o:" + player.getName());
+        changeInvName(chest.getState(), ((InventoryHolder) chest.getState()).getInventory().getName().toString(),
+                Collections.singletonList(plugin.getServer().getOfflinePlayer(player.getUniqueId())), Collections.emptyList());
 
         if (chestInventory.containsAtLeast(item1, amount1)) {
             event.getPlayer().sendMessage(colorize(getPrefix() + Message.SUCCESSFUL_SETUP));

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: TradeShop
-version: 1.7.1-BETA
+version: 1.7.2-BETA
 main: org.shanerx.tradeshop.TradeShop
 
 author: Lori00


### PR DESCRIPTION
Slightly changes formatting on chests and leaves original name so be reset to when chest is broken

-Works with old names, however doesn't change theirs names back yet
